### PR TITLE
Add comprehensive README for Jeep Wrangler JK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,90 @@
-# Model make
+# Jeep Wrangler JK
+
+This repository contains signal set configurations for the Jeep Wrangler JK, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Jeep Wrangler JK.
+
+## Generations
+
+The Jeep Wrangler JK (2007-2018) represents the third generation of the iconic Wrangler off-road vehicle, marking a significant evolution in design, capability, and mainstream appeal while maintaining core Jeep DNA:
+
+- **JK Generation (2007-2018)**: Complete clean-sheet redesign representing the apex of Wrangler's crossover appeal and modern off-road capability:
+  - August 2006: Production launch for 2007 model year
+  - Six years of design and testing development under DaimlerChrysler ownership
+  - First Wrangler with completely new body, frame, and suspension architecture
+  - Higher development budget allowed brand-new platform versus previous adaptations
+  - Successfully bridged traditional off-road capability with modern comfort features
+
+  **Dimensional Evolution:**
+  - Substantial size increases in nearly every dimension
+  - Two-door: Several inches of additional wheelbase and wider track
+  - Four-door Unlimited: 20-inch wheelbase stretch (versus 10-inch in previous Unlimited)
+  - Enhanced interior space while maintaining classic Wrangler proportions
+  - Improved on-road stability without compromising off-road geometry
+
+  **Body Configurations:**
+  - Two-door Wrangler: Traditional short-wheelbase configuration
+  - Four-door Wrangler Unlimited: Factory-standard long-wheelbase family variant
+  - Both configurations maintained removable doors and fold-flat windshield capability
+  - Convertible soft-top and optional hardtop configurations available
+
+- **Early Era (2007-2011)**: Initial production with transitional powertrain technology:
+  - **Engine:** 3.8L V6 replacing legendary 4.0L inline-six
+  - **Power Output:** 202 hp and 237 lb-ft torque
+  - **Transmission Options:** Four-speed automatic or six-speed manual
+  - **Challenges:** "Minivan motor" reputation due to shared Dodge/Chrysler application
+  - **Performance:** Adequate but less authoritative than previous 4.0L engine
+  - **Real-world Impact:** Marginal improvements despite higher paper specifications
+
+- **Mid-Generation Update (2012-2018)**: Transformative powertrain upgrade enhancing entire driving experience:
+  - **Engine:** 3.6L Pentastar V6 replacing 3.8L unit
+  - **Power Output:** 285 hp and 260 lb-ft torque (significant improvement)
+  - **Transmission:** Five-speed automatic replacing four-speed (improved reliability)
+  - **Performance:** Complete transformation of driving dynamics across all conditions
+  - **Efficiency:** Enhanced fuel economy while delivering superior performance
+  - **Reliability:** Improved long-term durability and reduced maintenance issues
+
+- **Off-Road Capability and Features**: Maintained traditional Jeep off-road excellence with modern enhancements:
+  - **Construction:** Separate body-on-frame design with rigid live axles front/rear
+  - **Drive System:** Part-time four-wheel drive with high/low range transfer case
+  - **Standard Features:** Off-road tuned ABS, traction control, electronic limited-slip differential
+  - **Traditional Elements:** Fold-flat windshield, removable doors, classic Jeep styling cues
+  - **Modern Safety:** Enhanced rollover protection and improved structural integrity
+
+- **Trim Level Hierarchy**: Comprehensive range addressing diverse user requirements:
+  - **Sport:** Base trim offering no-frills, back-to-basics off-road experience
+  - **Sahara:** Mid-level trim balancing on-road comfort with off-road capability
+  - **Rubicon:** Ultimate off-road focused variant with specialized equipment
+
+  **Rubicon Edition Specifications:**
+  - Dana 44 axles front and rear with 4.10 gearing
+  - Front and rear Tru-Lock electronic locking differentials
+  - Electronic sway bar disconnect system for enhanced articulation
+  - Increased ride height with larger diameter tires
+  - Rock rails and skid plates for underbody protection
+  - One of most capable stock off-road vehicles available
+
+- **Reliability and Longevity**: Established reputation for durability and long-term ownership satisfaction:
+  - Common lifespan exceeding 200,000 miles with proper maintenance
+  - Six-speed manual transmission particularly reliable and durable
+  - Five-speed automatic (2012+) more reliable than four-speed predecessor
+  - Strong aftermarket support and modification community
+  - Retained value excellence in used vehicle market
+
+- **Legacy and Successor**: Successful generation bridging traditional and modern Jeep expectations:
+  - 2018: Discontinued and replaced by fourth-generation JL
+  - Most successful Wrangler generation in terms of sales and mainstream acceptance
+  - Established template for modern Wrangler design philosophy
+  - Proved viability of four-door Wrangler configuration
+  - Set standard for combining authentic off-road capability with daily usability
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.
 


### PR DESCRIPTION
- Added complete JK generation history (2007-2018)
- Documented evolution from 3.8L to 3.6L Pentastar V6
- Covered two-door and four-door Unlimited configurations
- Included detailed Rubicon edition off-road specifications
- Added reliability information and successor transition
